### PR TITLE
Fix small errors on the Stripe module

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Think hard about how many invoices we're dealing with. We want this method to be
 We want you to show us two things:
 
 1. You can build a database backed Rails to implement real life billing
-1. You can solve problems for real life users. See `NOTES.md` down below
+2. You can solve problems for real life users. See `NOTES.md` down below
 
 For the invoice modeling piece, we care about the types you choose and whether you model items in a way that emphasizes the things our users care about.
 We want to see how you approached trade-offs and what you prioritize when making decisions for the migration.

--- a/lib/STRIPE-README.md
+++ b/lib/STRIPE-README.md
@@ -28,7 +28,7 @@ Stripe::Invoice.slow_with(10)
   Stripe::Invoice.retrieve("asdf") # waits 10 seconds
 end
 
-Stripe::Invoice.error_with(new StandardError("broken")) do
+Stripe::Invoice.error_with(StandardError.new("broken")) do
   Stripe::Invoice.retrieve("asdf")
   # => StandardError("broken")
 

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -49,7 +49,7 @@ module Stripe
         check_slow!
 
         if @retrieve_params.try(:length).to_i > 0
-          new({id:}.merge(@retrieve_params.last))
+          new({id: id}.merge(@retrieve_params.last))
         else
           raise Stripe::InvalidRequestError, "No such invoice: '#{id}'"
         end

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -79,7 +79,8 @@ module Stripe
     attr_reader :customer
 
     def initialize(params)
-      @id = params[:id]
+      @id = params[:id] || id
+      assign_attributes(params)
     end
 
     def id
@@ -105,7 +106,7 @@ module Stripe
     attr_reader :quantity
 
     def initialize(params)
-      @id = params[:id]
+      @id = params[:id] || id
       assign_attributes(params)
     end
 


### PR DESCRIPTION
Hi, Fly team. While solving the challenge I noticed there was syntax error when I tried to use the provided Stripe module. So here is the small fix to prevent other candidates from having the same issue.

Also I noticed that for `Stripe::InvoiceItem` the create method did assign the attributes while the one for `Stripe::Invoice` didn't, so I made that consistent. And finally I saw that the `id` method does generate an id if the object doesn't have one already, but this was not used on `initialize`, so I added it. Now calling `create` does assign a random id if none passed.

There were also a couple of missing links in the README. I added the same one in both places as I guessed they were supposed to link to the job description. And finally, there was also a small syntax error on the STRIPE-README.